### PR TITLE
Update marketplace listing name and short description

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ LABEL repository="https://github.com/serverless/github-action"
 LABEL homepage="https://github.com/serverless/github-action"
 LABEL maintainer="Serverless, Inc. <hello@serverless.com> (https://serverless.com)"
 
-LABEL "com.github.actions.name"="Serverless"
-LABEL "com.github.actions.description"="Wraps the Serverless Framework to enable common Serverless commands."
+LABEL "com.github.actions.name"="Serverless Framework"
+LABEL "com.github.actions.description"="Wraps the Serverless Framework to enable common Serverless commands"
 LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="red"
 


### PR DESCRIPTION
Typo in short description on the marketplace listing for this action. Missing a **w** in the word *framework*.